### PR TITLE
Changes needed to support Python 2.7.

### DIFF
--- a/bin/rst2ansi
+++ b/bin/rst2ansi
@@ -1,8 +1,9 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import sys
 from rst2ansi import rst2ansi
 import argparse
+import io
 
 parser = argparse.ArgumentParser(description='Prints a reStructuredText input in an ansi-decorated format suitable for console output.')
 parser.add_argument('file', type=str, nargs='?', help='A path to the file to open')
@@ -15,7 +16,7 @@ def process_file(f):
     print(out)
 
 if args.file:
-  with open(args.file, 'r') as f:
+  with io.open(args.file, 'rb') as f:
     process_file(f)
 else:
   process_file(sys.stdin)

--- a/rst2ansi/__init__.py
+++ b/rst2ansi/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 The MIT License (MIT)
 
@@ -22,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from __future__ import unicode_literals
+
 from docutils import nodes, core
 from docutils.parsers.rst import roles
 
@@ -42,5 +45,5 @@ def rst2ansi(input_string, output_encoding='utf-8'):
   for style in STYLES:
     roles.register_local_role('ansi-' + style, style_role)
 
-  out = core.publish_string(input_string, settings_overrides=overrides, writer=Writer(unicode=output_encoding.startswith('utf')))
+  out = core.publish_string(input_string.decode('utf-8'), settings_overrides=overrides, writer=Writer(unicode=output_encoding.startswith('utf')))
   return out.decode(output_encoding)

--- a/rst2ansi/ansi.py
+++ b/rst2ansi/ansi.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 The MIT License (MIT)
 
@@ -22,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from __future__ import unicode_literals
+
 from docutils import core, frontend, nodes, utils, writers, languages, io
 from docutils.utils.error_reporting import SafeString
 from docutils.transforms import writer_aux
@@ -31,7 +34,9 @@ from copy import deepcopy, copy
 from .wrap import wrap
 
 from .table import TableSizeCalculator, TableWriter
-from .unicode import ref_to_unicode
+from .unicode import ref_to_unicode, u
+
+from .get_terminal_size import get_terminal_size
 
 import shutil
 
@@ -105,7 +110,7 @@ class ANSITranslator(nodes.NodeVisitor):
     self.lines = ['']
     self.line = 0
     self.indent_width = 2
-    self.termsize = termsize or shutil.get_terminal_size((80,20))
+    self.termsize = termsize or get_terminal_size((80,20))
     self.options = options
     self.references = []
     self.refcount = 0
@@ -142,12 +147,16 @@ class ANSITranslator(nodes.NodeVisitor):
             not self.style.styles
     self._restyle(reset)
 
-  def append(self, *args, strict=False):
+  def append(self, *args, **kwargs):
+    try:
+      strict = kwargs['strict']
+    except KeyError:
+      strict = False
     if len(self.lines[self.line]) == 0 and not strict:
       self.lines[self.line] += ' ' * self.ctx.indent_level * self.indent_width
 
     for a in args:
-      self.lines[self.line] += str(a)
+      self.lines[self.line] += u(a)
 
   def newline(self, n=1):
     self.lines.extend([''] * n)

--- a/rst2ansi/functional.py
+++ b/rst2ansi/functional.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 The MIT License (MIT)
 

--- a/rst2ansi/get_terminal_size.py
+++ b/rst2ansi/get_terminal_size.py
@@ -1,0 +1,101 @@
+"""This is a backport of shutil.get_terminal_size from Python 3.3.
+
+The original implementation is in C, but here we use the ctypes and
+fcntl modules to create a pure Python version of os.get_terminal_size.
+"""
+
+import os
+import struct
+import sys
+
+from collections import namedtuple
+
+__all__ = ["get_terminal_size"]
+
+
+terminal_size = namedtuple("terminal_size", "columns lines")
+
+try:
+    from ctypes import windll, create_string_buffer, WinError
+
+    _handle_ids = {
+        0: -10,
+        1: -11,
+        2: -12,
+    }
+
+    def _get_terminal_size(fd):
+        handle = windll.kernel32.GetStdHandle(_handle_ids[fd])
+        if handle == 0:
+            raise OSError('handle cannot be retrieved')
+        if handle == -1:
+            raise WinError()
+        csbi = create_string_buffer(22)
+        res = windll.kernel32.GetConsoleScreenBufferInfo(handle, csbi)
+        if res:
+            res = struct.unpack("hhhhHhhhhhh", csbi.raw)
+            left, top, right, bottom = res[5:9]
+            columns = right - left + 1
+            lines = bottom - top + 1
+            return terminal_size(columns, lines)
+        else:
+            raise WinError()
+
+except ImportError:
+    import fcntl
+    import termios
+
+    def _get_terminal_size(fd):
+        try:
+            res = fcntl.ioctl(fd, termios.TIOCGWINSZ, b"\x00" * 4)
+        except IOError as e:
+            raise OSError(e)
+        lines, columns = struct.unpack("hh", res)
+
+        return terminal_size(columns, lines)
+
+
+def get_terminal_size(fallback=(80, 24)):
+    """Get the size of the terminal window.
+
+    For each of the two dimensions, the environment variable, COLUMNS
+    and LINES respectively, is checked. If the variable is defined and
+    the value is a positive integer, it is used.
+
+    When COLUMNS or LINES is not defined, which is the common case,
+    the terminal connected to sys.__stdout__ is queried
+    by invoking os.get_terminal_size.
+
+    If the terminal size cannot be successfully queried, either because
+    the system doesn't support querying, or because we are not
+    connected to a terminal, the value given in fallback parameter
+    is used. Fallback defaults to (80, 24) which is the default
+    size used by many terminal emulators.
+
+    The value returned is a named tuple of type os.terminal_size.
+    """
+    # Try the environment first
+    try:
+        columns = int(os.environ["COLUMNS"])
+    except (KeyError, ValueError):
+        columns = 0
+
+    try:
+        lines = int(os.environ["LINES"])
+    except (KeyError, ValueError):
+        lines = 0
+
+    # Only query if necessary
+    if columns <= 0 or lines <= 0:
+        try:
+            size = _get_terminal_size(sys.__stdout__.fileno())
+        except (NameError, OSError):
+            size = terminal_size(*fallback)
+
+        if columns <= 0:
+            columns = size.columns
+        if lines <= 0:
+            lines = size.lines
+
+    return terminal_size(columns, lines)
+

--- a/rst2ansi/get_terminal_size.py
+++ b/rst2ansi/get_terminal_size.py
@@ -2,6 +2,31 @@
 
 The original implementation is in C, but here we use the ctypes and
 fcntl modules to create a pure Python version of os.get_terminal_size.
+
+Pulled from https://github.com/chrippa/backports.shutil_get_terminal_size
+
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Christopher Rosell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 """
 
 import os

--- a/rst2ansi/table.py
+++ b/rst2ansi/table.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 The MIT License (MIT)
 
@@ -22,9 +23,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from __future__ import unicode_literals
+
 from docutils import nodes
 
 from textwrap import wrap
+
+from .unicode import u
 
 class CellDimCalculator(nodes.NodeVisitor):
 
@@ -157,7 +162,7 @@ class TableDrawer(nodes.NodeVisitor):
           (' ', '═'): '╛',
           ('╘', '═'): '╘',
         }
-      return switch[(char, next)]
+      return switch[(u(char), u(next))]
 
     if options.get('unicode', False):
       self.char_single_rule = '─'

--- a/rst2ansi/unicode.py
+++ b/rst2ansi/unicode.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 The MIT License (MIT)
 
@@ -22,20 +23,38 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-def num_to_superscript(n: int):
+from __future__ import unicode_literals
+
+import sys
+
+def num_to_superscript(n):
   sups = {
-    u'0': u'\u2070',
-    u'1': u'\xb9',
-    u'2': u'\xb2',
-    u'3': u'\xb3',
-    u'4': u'\u2074',
-    u'5': u'\u2075',
-    u'6': u'\u2076',
-    u'7': u'\u2077',
-    u'8': u'\u2078',
-    u'9': u'\u2079'
+    '0': '\u2070',
+    '1': '\xb9',
+    '2': '\xb2',
+    '3': '\xb3',
+    '4': '\u2074',
+    '5': '\u2075',
+    '6': '\u2076',
+    '7': '\u2077',
+    '8': '\u2078',
+    '9': '\u2079'
   }
   return ''.join(sups.get(c, c) for c in str(n))
 
-def ref_to_unicode(n: int):
+def ref_to_unicode(n):
   return '⁽' + num_to_superscript(n) + '⁾'
+
+def u(s):
+  # Useful for very coarse version differentiation.
+  PY2 = sys.version_info[0] == 2
+  PY3 = sys.version_info[0] == 3
+  if PY3:
+    return s
+  else:
+    # Workaround for standalone backslash
+    try:
+        ret_s = unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    except TypeError:
+        ret_s = s.replace(r'\\', r'\\\\')
+    return ret_s

--- a/rst2ansi/visitor.py
+++ b/rst2ansi/visitor.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 The MIT License (MIT)
 

--- a/rst2ansi/wrap.py
+++ b/rst2ansi/wrap.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 The MIT License (MIT)
 
@@ -33,21 +34,25 @@ def wrap(text, width=80, subsequent_indent=''):
   words = text.split()
   line_size = 0
   lines = [[]]
-  def nl():
-    nonlocal line_size, lines
-    line_size = len(subsequent_indent)
-    lines.append([])
+  #def nl():
+  #  nonlocal line_size, lines
+  #  line_size = len(subsequent_indent)
+  #  lines.append([])
 
   for w in words:
     size = word_size(w) + 1
     if size == 0:
       continue
     if line_size + size - 1 > width and line_size > width / 2:
-      nl()
+      #nl()
+      line_size = len(subsequent_indent)
+      lines.append([])
     while line_size + size - 1 > width:
       stripped = width - line_size - 1
       lines[-1].append(w[:stripped] + '-')
-      nl()
+      #nl()
+      line_size = len(subsequent_indent)
+      lines.append([])
       w = w[stripped:]
       size -= stripped
     if size == 0:

--- a/rst2ansi/wrap.py
+++ b/rst2ansi/wrap.py
@@ -34,23 +34,17 @@ def wrap(text, width=80, subsequent_indent=''):
   words = text.split()
   line_size = 0
   lines = [[]]
-  #def nl():
-  #  nonlocal line_size, lines
-  #  line_size = len(subsequent_indent)
-  #  lines.append([])
 
   for w in words:
     size = word_size(w) + 1
     if size == 0:
       continue
     if line_size + size - 1 > width and line_size > width / 2:
-      #nl()
       line_size = len(subsequent_indent)
       lines.append([])
     while line_size + size - 1 > width:
       stripped = width - line_size - 1
       lines[-1].append(w[:stripped] + '-')
-      #nl()
       line_size = len(subsequent_indent)
       lines.append([])
       w = w[stripped:]

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,6 @@ try:
 except ImportError:
   from distutils.core import setup
 
-if sys.version_info < (3, 3, 0):
-  print('This module is not supported on versions lower than python 3.3, sorry !')
-  print('Your version of python is %s, try installing it with a more recent version.'
-        % '.'.join(map(str, sys.version_info[:3])))
-  sys.exit(1)
-
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
@@ -37,7 +31,8 @@ setup(
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.3",
     "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
Don't know how you feel about Python 2, but I am trying to support 2 and 3 in my projects.  I have helped out a little bit with 'mando', which I use in almost all my projects.   I think that rst2ansi would be fantastic way to display mando's help, which is taken from rst docstrings.  Mando supports 2.6 onward, but moving rst2ansi to Python 2.6 looked to be a little more difficult than just supporting 2.7.

Kindest regards,
Tim
