### PR TITLE
Added tests for bullet, enumerated, option, and definition lists and fixed up some list formatting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,9 @@ This document describes the TODO list for supporing the full [reStructuredText s
   * [x] Paragraphs
   * [x] Bullet Lists
   * [x] Enumerated Lists
-  * [ ] Definition Lists
+  * [x] Definition Lists
   * [ ] Field Lists
-  * [ ] Option Lists
+  * [x] Option Lists
   * [x] Literal Blocks
   * [x] Line Blocks
   * [ ] Block Quotes

--- a/bin/rst2ansi
+++ b/bin/rst2ansi
@@ -13,7 +13,10 @@ args = parser.parse_args()
 def process_file(f):
   out = rst2ansi(f.read())
   if out:
-    print(out)
+    try:
+      print(out)
+    except UnicodeEncodeError:
+      print(out.encode('ascii', errors='backslashreplace').decode('ascii'))
 
 if args.file:
   with io.open(args.file, 'rb') as f:

--- a/rst2ansi/ansi.py
+++ b/rst2ansi/ansi.py
@@ -336,7 +336,9 @@ class ANSITranslator(nodes.NodeVisitor):
   # Lists
 
   def visit_enumerated_list(self, node):
-    self.push_ctx(in_list = True, list_counter = 1)
+    strt = node.attributes.get('start', 1)
+    self.push_ctx(in_list = True,
+                  list_counter = strt)
 
   def depart_enumerated_list(self, node):
     self.pop_ctx()
@@ -344,7 +346,8 @@ class ANSITranslator(nodes.NodeVisitor):
       self.newline()
 
   def visit_bullet_list(self, node):
-    self.push_ctx(in_list = True, list_counter = 0)
+    self.push_ctx(in_list = True,
+                  list_counter = 0)
 
   def depart_bullet_list(self, node):
     self.pop_ctx()
@@ -366,12 +369,12 @@ class ANSITranslator(nodes.NodeVisitor):
   depart_definition_list = npartial(pop_ctx)
 
   def visit_definition(self, node):
-    self.newline(2)
+    self.newline()
     self.push_ctx(indent_level = self.ctx.indent_level + 1)
 
   def depart_definition(self, node):
-    self.pop_ctx()
     self.newline()
+    self.pop_ctx()
 
   visit_option_list = npartial(push_ctx, in_list=True, list_counter=0)
   depart_option_list = npartial(pop_ctx)
@@ -380,7 +383,7 @@ class ANSITranslator(nodes.NodeVisitor):
     self.append(' | ')
 
   def depart_option_group(self, node):
-    self.replaceline(self.lines[self.line][:-3] + ':', strict=True)
+    self.replaceline(self.lines[self.line][:-3], strict=True)
     self.push_ctx(indent_level = self.ctx.indent_level + 2)
     self.newline()
 
@@ -389,7 +392,6 @@ class ANSITranslator(nodes.NodeVisitor):
 
   def depart_option_list_item(self, node):
     self.pop_ctx()
-    self.newline()
 
   # Tables
 

--- a/test/lists.t
+++ b/test/lists.t
@@ -1,0 +1,151 @@
+Docutils bullet list:
+  $ echo "
+  > Docutils Bullet List
+  > 
+  > - This is item 1 
+  > - This is item 2
+  > 
+  > - Bullets are '-', '*' or '+'. 
+  >   Continuing text must be aligned 
+  >   after the bullet and whitespace.
+  > 
+  > Note that a blank line is required 
+  > before the first item and after the 
+  > last, but is optional between items.
+  > " > paragraph.rst
+  $ rst2ansi paragraph.rst
+  Docutils Bullet List
+  
+    \u2022 This is item 1
+    \u2022 This is item 2
+    \u2022 Bullets are '-', '*' or '+'. Continuing text must be aligned after the
+    bullet and whitespace.
+  
+  Note that a blank line is required before the first item and after the last, but
+  is optional between items.
+
+Docutils enumerated lists:
+  $ echo "
+  > Docutils Enumerated List
+  > 
+  > 3. This is the first item 
+  > 4. This is the second item 
+  > 5. Enumerators are arabic numbers, 
+  >    single letters, or roman numerals 
+  > 6. List items should be sequentially 
+  >    numbered, but need not start at 1 
+  >    (although not all formatters will 
+  >    honour the first index). 
+  > #. This item is auto-enumerated
+  > " > paragraph.rst
+  $ rst2ansi paragraph.rst
+  Docutils Enumerated List
+  
+    3. This is the first item
+    4. This is the second item
+    5. Enumerators are arabic numbers, single letters, or roman numerals
+    6. List items should be sequentially numbered, but need not start at 1
+    (although not all formatters will honour the first index).
+    7. This item is auto-enumerated
+
+Test bullet list:
+  $ echo "
+  > Simple bullet list
+  > 
+  > * list 1
+  > * list 2 with multiple
+  >   lines
+  > * list 3
+  > " > paragraph.rst
+  $ rst2ansi paragraph.rst
+  Simple bullet list
+  
+    \u2022 list 1
+    \u2022 list 2 with multiple lines
+    \u2022 list 3
+
+Test definition list:
+  $ echo "
+  > Definition list
+  > 
+  > Dinner
+  >   An evening meal.
+  > 
+  > Lunch
+  >   A meal
+  >   typically
+  >   taken
+  >   mid day
+  > 
+  > Breakfast
+  >   Morning meal that 'breaks' the overnight 'fast'.
+  > " > paragraph.rst
+  $ rst2ansi paragraph.rst
+  Definition list
+  
+  Dinner
+    An evening meal.
+  
+  Lunch
+    A meal typically taken mid day
+  
+  Breakfast
+    Morning meal that 'breaks' the overnight 'fast'.
+
+Option list:
+  $ echo "
+  > Option List
+  > 
+  > -a            command-line option 'a' 
+  > -b file       options can have arguments 
+  >               and long descriptions 
+  > --long        options can be long also 
+  > --input file  long options can also have 
+  >               arguments
+  >               TODO: This should work with --input=file also
+  > /V            DOS/VMS-style options too
+  > --text        This is a long text that should span the line so that I can
+  >               see if there is the correct word wrap.  If there
+  >               isn't it could be problem, but maybe not.
+  > " > paragraph.rst
+  $ rst2ansi paragraph.rst
+  Option List
+  
+  -a
+      command-line option 'a'
+  -b file
+      options can have arguments and long descriptions
+  --long
+      options can be long also
+  --input file
+      long options can also have arguments TODO: This should work with
+      --input=file also
+  /V
+      DOS/VMS-style options too
+  --text
+      This is a long text that should span the line so that I can see if there is
+      the correct word wrap. If there isn't it could be problem, but maybe
+      not.
+
+Check Sub List:
+  $ echo "
+  > #. numbered
+  > #. list
+  > 
+  >    #. and a
+  >    #. sublist
+  > 
+  > #. end
+  > 
+  > * unordered
+  > * list
+  > " > paragraph.rst
+  $ rst2ansi paragraph.rst
+    1. numbered
+    2. list
+      1. and a
+      2. sublist
+    3. end
+  
+    \u2022 unordered
+    \u2022 list


### PR DESCRIPTION
Added tests for lists and fixed up some of the formatting.

I allowed two tests to pass because I felt the issues where minor, but for the future:
- Correctly wrap sublines of long enumerated list items.
  This:

```
    6. List items should be sequentially numbered, but need not start at 1      
    (although not all formatters will honour the first index).                  
```

should be:

```
    6. List items should be sequentially numbered, but need not start at 1      
       (although not all formatters will honour the first index).                  
```
- Option list strips out the '=' sign.
  This:

```
  --input file                                                                  
      long options can also have arguments TODO: This should work with          
      --input=file also                                                         
```

should allow for:

```
  --input=file                                                                  
      long options can also have arguments TODO: This should work with          
      --input=file also                                                         
```
