### PR TITLE
Fix issue #16

### DIFF
--- a/rst2ansi/ansi.py
+++ b/rst2ansi/ansi.py
@@ -26,7 +26,6 @@ THE SOFTWARE.
 from __future__ import unicode_literals
 
 from docutils import core, frontend, nodes, utils, writers, languages, io
-from docutils.utils.error_reporting import SafeString
 from docutils.transforms import writer_aux
 from docutils.parsers.rst import roles
 

--- a/rst2ansi/visitor.py
+++ b/rst2ansi/visitor.py
@@ -24,7 +24,6 @@ THE SOFTWARE.
 """
 
 from docutils import core, frontend, nodes, utils, writers, languages, io
-from docutils.utils.error_reporting import SafeString
 from docutils.transforms import writer_aux
 from docutils.parsers.rst import roles
 


### PR DESCRIPTION
Removed unused, deprecated, docutils imports.  These imports cause modern builds of apps which depend on rst2ansi to fail due to the (unused) references to the docutils error_reporting package, which no longer exists.