### PR TITLE
Fix buffer overflow in TIOCGWINSZ ioctl for Python 3.14+

### DIFF
--- a/rst2ansi/get_terminal_size.py
+++ b/rst2ansi/get_terminal_size.py
@@ -72,10 +72,10 @@ except ImportError:
 
     def _get_terminal_size(fd):
         try:
-            res = fcntl.ioctl(fd, termios.TIOCGWINSZ, b"\x00" * 4)
+            res = fcntl.ioctl(fd, termios.TIOCGWINSZ, b"\x00" * 8)
         except IOError as e:
             raise OSError(e)
-        lines, columns = struct.unpack("hh", res)
+        lines, columns, *_ = struct.unpack("hhhh", res)
 
         return terminal_size(columns, lines)
 


### PR DESCRIPTION
Fixes #18

## Problem

Python 3.14 introduced stricter buffer validation for ioctl calls. The current code passes a 4-byte buffer to TIOCGWINSZ, but it expects struct winsize (4 unsigned shorts = 8 bytes). This causes SystemError on Python 3.14+.

## Solution

- Increase buffer from 4 to 8 bytes
- Update struct format from "hh" to "hhhh" 
- Unpack all 4 values but only use first 2 (rows, columns)

This matches the fix used by PyInvoke: https://github.com/pyinvoke/invoke/pull/1040

## Testing

Tested on Python 3.14 with B2 CLI which depends on rst2ansi.